### PR TITLE
fix: update dependencies to resolve Dependabot security alerts

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "@react-navigation/native": "^5.7.1",
     "@react-navigation/stack": "^5.7.1",
     "idx": "^2.5.6",
-    "lodash": "^4.17.19",
+    "lodash": "^4.18.0",
     "prop-types": "^15.7.2",
     "react": "16.13.1",
     "react-native": "0.63.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4449,6 +4449,11 @@ lodash@^4.17.10, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.3.
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.19.tgz#e48ddedbe30b3321783c5b4301fbd353bc1e4a4b"
   integrity sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==
 
+lodash@^4.18.0:
+  version "4.18.1"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.18.1.tgz#ff2b66c1f6326d59513de2407bf881439812771c"
+  integrity sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==
+
 log-symbols@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/log-symbols/-/log-symbols-2.2.0.tgz#5740e1c5d6f0dfda4ad9323b5332107ef6b4c40a"


### PR DESCRIPTION
## Summary

This PR fixes high-severity security vulnerabilities in project dependencies.

## CVEs Fixed

- **CVE-2026-4800** (GHSA-r5fr-rjxr-66jc): lodash Code Injection via `\_.template`
  - **Patched version**: 4.18.0
  - **Severity**: High (CVSS 8.1)
  - **Details**: The fix for CVE-2021-23337 added validation for the `variable` option but did not apply the same validation to `options.imports` key names, allowing arbitrary code execution at template compilation time.

- **CVE-2026-2950** (GHSA-f23m-r3pf-42rh): lodash Prototype Pollution
  - **Patched version**: 4.18.0
  - **Severity**: Medium (CVSS 6.5)
  - **Details**: The fix for CVE-2025-13465 only guards against string key members, allowing bypass via array-wrapped path segments in `_.unset` and `_.omit` functions.

## Changes

- Updated lodash from `^4.17.19` to `^4.18.0`
- Updated yarn.lock with secure dependency versions

## Testing

- Ran `yarn install` successfully
- Verified no regressions in dependency resolution

## Additional Notes

The remaining vulnerabilities (react-native, ansi-regex in chalk, xmldom, tmp, uuid, picomatch, flatted, minimatch) are in transitive dependencies controlled by React Native and its CLI tools. These require framework-level updates and are outside the scope of direct package.json changes.