### PR TITLE
🔒 fix(security): update lodash to 4.18.1 (CVE-2026-4800)

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "@react-navigation/native": "^5.7.1",
     "@react-navigation/stack": "^5.7.1",
     "idx": "^2.5.6",
-    "lodash": "4.17.23",
+    "lodash": "4.18.1",
     "prop-types": "^15.7.2",
     "react": "16.13.1",
     "react-native": "0.63.2",
@@ -52,10 +52,10 @@
   },
   "overrides": {
     "shell-quote": "^1.7.3",
-    "lodash": "4.17.23"
+    "lodash": "4.18.1"
   },
   "resolutions": {
-    "lodash": "4.17.23",
+    "lodash": "4.18.1",
     "shell-quote": "1.7.3"
   }
 }


### PR DESCRIPTION
## 🔐 Security Fix: CVE-2026-4800

**Severity:** High
**Package:** lodash
**Vulnerable version:** 4.17.23
**Patched version:** 4.18.1

### Summary

Updates lodash from 4.17.23 to 4.18.1 to resolve CVE-2026-4800, a high-severity security vulnerability.

### Changes

- Updated `lodash` in **dependencies**: `4.17.23` → `4.18.1`
- Updated `lodash` in **overrides**: `4.17.23` → `4.18.1`
- Updated `lodash` in **resolutions**: `4.17.23` → `4.18.1`

### Why all three locations?

- **dependencies**: Direct dependency version
- **overrides (npm)**: Forces all transitive dependencies to use patched version
- **resolutions (yarn)**: Forces all transitive dependencies to use patched version (yarn equivalent)

This ensures no dependency in the tree can pull in the vulnerable version.

### Testing

- [ ] Verify app builds and runs correctly
- [ ] Run `yarn audit` to confirm lodash vulnerability is resolved
- [ ] Check that no runtime errors occur from lodash usage